### PR TITLE
install cover and cover-coveralls separately for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,17 @@ env:
   matrix:
     - RACKET_VERSION=6.1.1
     - RACKET_VERSION=6.2
+    - RACKET_VERSION=6.2.1
+    - RACKET_VERSION=6.3
+    - RACKET_VERSION=6.4
+    - RACKET_VERSION=6.5
     - RACKET_VERSION=HEAD
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
   - export PATH="${RACKET_DIR}/bin:${PATH}"
+  - raco pkg install --deps search-auto cover cover-coveralls
 
 install: raco pkg install --deps search-auto $TRAVIS_BUILD_DIR
 

--- a/info.rkt
+++ b/info.rkt
@@ -18,7 +18,6 @@
 (define build-deps
   '("scribble-doc"
     "rackunit-lib"
-    "cover"
     "racket-doc"
     "scribble-lib"
     "doc-coverage"))


### PR DESCRIPTION
This makes it no longer necessary for this to depend on the cover package outside of travis builds.
