### PR TITLE
depend on sweet-exp-lib instead of sweet-exp

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -10,7 +10,7 @@
 (define deps
   '("scribble-lib"
     "base"
-    "sweet-exp"
+    "sweet-exp-lib"
     "reprovide-lang"
     "fancy-app"))
 


### PR DESCRIPTION
The `sweet-exp` package has now been split into the `sweet-exp-lib`, `sweet-exp-test`, and `sweet-exp` packages, and `sweet-exp-lib` is the implementation part of it.
