### PR TITLE
Depend on reprovide-lang-lib, not reprovide-lang

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -11,7 +11,7 @@
   '("scribble-lib"
     "base"
     "sweet-exp-lib"
-    "reprovide-lang"
+    "reprovide-lang-lib"
     "fancy-app"))
 
 


### PR DESCRIPTION
The `reprovide-lang` package has been split so that the modules are now in `reprovide-lang-lib` and the docs and tests are in `reprovide-lang`.

Related to https://github.com/jackfirth/lens/pull/307